### PR TITLE
Fix Presentation for conditional views

### DIFF
--- a/Sources/Portal/PortalContainer.swift
+++ b/Sources/Portal/PortalContainer.swift
@@ -38,19 +38,26 @@ public struct PortalContainer<Content: View>: View {
 
     public var body: some View {
         content
+            .onAppear {
+                setupWindow(scene)
+            }
             .onChange(of: scene) { newValue in
-                #if canImport(UIKit)
-                if newValue == .active {
-                    OverlayWindowManager.shared.addOverlayWindow(
-                        with: portalModel,
-                        hideStatusBar: hideStatusBar
-                    )
-                } else {
-                    OverlayWindowManager.shared.removeOverlayWindow()
-                }
-                #endif
+                setupWindow(newValue)
             }
             .environmentObject(portalModel)
+    }
+
+    private func setupWindow(_ scenePhase: ScenePhase) {
+        #if canImport(UIKit)
+        if scenePhase == .active {
+            OverlayWindowManager.shared.addOverlayWindow(
+                with: portalModel,
+                hideStatusBar: hideStatusBar
+            )
+        } else {
+            OverlayWindowManager.shared.removeOverlayWindow()
+        }
+        #endif
     }
 }
 

--- a/Sources/Portal/PortalContainer.swift
+++ b/Sources/Portal/PortalContainer.swift
@@ -41,7 +41,7 @@ public struct PortalContainer<Content: View>: View {
             .onAppear {
                 setupWindow(scene)
             }
-            .onChange(of: scene) { newValue in
+            .onChangeCompat(of: scene) { newValue in
                 setupWindow(newValue)
             }
             .environmentObject(portalModel)
@@ -122,6 +122,7 @@ final class OverlayWindowManager {
                 root.view.frame = windowScene.screen.bounds
 
                 window.rootViewController = root
+                guard self.overlayWindow == nil else { return }
                 self.overlayWindow = window
                 break
             }


### PR DESCRIPTION
Fixes a bug where conditionally presented views do not get their overlay window set up.

See this example 
```Swift
struct ContentView: View {
    @State var x: Bool = false

    var body: some View {
        VStack {
            if x {
                Portal_SheetExample()
            }
        }
        .task {
            x.toggle()
        }
    }
}
```

When Portal_SheetExample() appears, the scenePhase onChange is never triggered, so the overlay window is not set up. For a non-conditional view, onChange does fire, which is why it worked correctly.

I guess the other solution is to wrap the entire root view in a `PortalContainer`, but this is not specified in the docs.