### PR TITLE
Fix portal frames after views leave the hierarchy

### DIFF
--- a/Sources/PortalTransitions/Core/CrossModel.swift
+++ b/Sources/PortalTransitions/Core/CrossModel.swift
@@ -124,8 +124,8 @@ public class CrossModel: Hashable {
         info[fromIndex].layerView = nil
         info[fromIndex].sourceAnchor = nil
         info[fromIndex].destinationAnchor = nil
-        info[fromIndex].cachedSourceAnchor = nil
-        info[fromIndex].cachedDestinationAnchor = nil
+        info[fromIndex].cachedSourceRect = nil
+        info[fromIndex].cachedDestinationRect = nil
 
         PortalLogs.logger.log(
             "Transferred active portal",

--- a/Sources/PortalTransitions/Core/PortalInfo.swift
+++ b/Sources/PortalTransitions/Core/PortalInfo.swift
@@ -168,11 +168,11 @@ public struct PortalInfo: Identifiable {
     /// Set when the source view reports its position through the preference system.
     public var sourceAnchor: Anchor<CGRect>?
 
-    /// Cached source anchor used during transitions even if view is removed from hierarchy.
+    /// Last valid resolved source frame used when the source view leaves the hierarchy.
     ///
-    /// This ensures the transition layer can continue animating even if the source view
-    /// disappears mid-transition (e.g., during sheet dismissal).
-    public var cachedSourceAnchor: Anchor<CGRect>?
+    /// Anchors are lookup tokens, so they cannot safely be resolved after their view has
+    /// been removed. This concrete frame keeps the transition layer positioned correctly.
+    public var cachedSourceRect: CGRect?
 
     /// Animation for the portal transition.
     ///
@@ -211,11 +211,11 @@ public struct PortalInfo: Identifiable {
     /// Set when the destination view reports its position through the preference system.
     public var destinationAnchor: Anchor<CGRect>?
 
-    /// Cached destination anchor used during transitions even if view is removed from hierarchy.
+    /// Last valid resolved destination frame used when the destination view leaves the hierarchy.
     ///
-    /// This ensures the transition layer can continue animating even if the destination view
-    /// disappears mid-transition (e.g., during sheet dismissal).
-    public var cachedDestinationAnchor: Anchor<CGRect>?
+    /// Anchors are lookup tokens, so they cannot safely be resolved after their view has
+    /// been removed. This concrete frame keeps the transition layer positioned correctly.
+    public var cachedDestinationRect: CGRect?
 
     /// Completion callback executed when the portal animation finishes.
     ///

--- a/Sources/PortalTransitions/Views/Portal.swift
+++ b/Sources/PortalTransitions/Views/Portal.swift
@@ -93,16 +93,8 @@ public struct Portal<Content: View>: View {
                 // Keep anchors aligned with live layout so animated layer follows scrolling/dragging
                 if isSource {
                     model.info[idx].sourceAnchor = anchor
-                    // Cache anchor for use during transitions if view is removed
-                    if model.info[idx].initialized {
-                        model.info[idx].cachedSourceAnchor = anchor
-                    }
                 } else {
                     model.info[idx].destinationAnchor = anchor
-                    // Cache anchor for use during transitions if view is removed
-                    if model.info[idx].initialized {
-                        model.info[idx].cachedDestinationAnchor = anchor
-                    }
                 }
             }
     }

--- a/Sources/PortalTransitions/Views/PortalLayerView.swift
+++ b/Sources/PortalTransitions/Views/PortalLayerView.swift
@@ -90,23 +90,34 @@ private struct PortalLayerContentView: View {
     /// - Uses `info.animateView` flag to determine current target values
     ///
     /// **Coordinate System:**
-    /// - Uses `proxy[anchor]` to convert anchor bounds to global coordinates
+    /// - Uses `proxy[anchor]` to convert live anchor bounds to concrete coordinates
     /// - Positions layer using `.offset()` for precise placement
     /// - Uses `.frame()` for size animation
     var body: some View {
-        // Use cached anchors if live ones are nil (views removed from hierarchy during transition)
-        let sourceToUse = info.sourceAnchor ?? info.cachedSourceAnchor
-        let destinationToUse = info.destinationAnchor ?? info.cachedDestinationAnchor
+        let liveSourceRect = resolvedFrame(for: info.sourceAnchor)
+        let liveDestinationRect = resolvedFrame(for: info.destinationAnchor)
+        let sourceRect = liveSourceRect ?? info.cachedSourceRect
+        let destinationRect = liveDestinationRect ?? info.cachedDestinationRect
 
-        if let source = sourceToUse,
-           let destination = destinationToUse,
+        return Group {
+            Color.clear
+                .allowsHitTesting(false)
+                .onAppear {
+                    cacheLiveFrames(source: liveSourceRect, destination: liveDestinationRect)
+                }
+                .onChange(of: liveSourceRect) { _, source in
+                    cacheLiveFrames(source: source, destination: nil)
+                }
+                .onChange(of: liveDestinationRect) { _, destination in
+                    cacheLiveFrames(source: nil, destination: destination)
+                }
+
+            if let sRect = sourceRect,
+               let dRect = destinationRect,
            let layer = info.layerView,
            info.showLayer {
-            let usingCachedSrc = info.sourceAnchor == nil
-            let usingCachedDst = info.destinationAnchor == nil
-            // Convert anchor bounds to concrete rectangles in global coordinate space
-            let sRect = proxy[source]
-            let dRect = proxy[destination]
+            let usingCachedSrc = liveSourceRect == nil
+            let usingCachedDst = liveDestinationRect == nil
             let animate = info.animateView
 
             // Interpolate size between source and destination based on animation state
@@ -181,7 +192,7 @@ private struct PortalLayerContentView: View {
                     ]
                 )
             }
-        } else {
+            } else {
             let hasSource = info.sourceAnchor != nil
             let hasDest = info.destinationAnchor != nil
             let hasLayer = info.layerView != nil
@@ -201,6 +212,22 @@ private struct PortalLayerContentView: View {
                         ]
                     )
                 }
+            }
         }
+    }
+
+    private func cacheLiveFrames(source: CGRect?, destination: CGRect?) {
+        if let source {
+            info.cachedSourceRect = source
+        }
+        if let destination {
+            info.cachedDestinationRect = destination
+        }
+    }
+
+    private func resolvedFrame(for anchor: Anchor<CGRect>?) -> CGRect? {
+        guard let anchor else { return nil }
+        let frame = proxy[anchor]
+        return frame.isEmpty ? nil : frame
     }
 }


### PR DESCRIPTION
## Summary
- Resolve live portal anchors to concrete frames and cache the last valid source and destination rectangles.
- Use cached frames when an anchor is unavailable or resolves to an empty rectangle after its view leaves the hierarchy.
- Clear cached frames when portal state is transferred.

Fixes #69