### PR TITLE
Document AsyncImage and NavigationStack portal transitions

### DIFF
--- a/docs/PortalTransitions/BasicUsage.md
+++ b/docs/PortalTransitions/BasicUsage.md
@@ -59,6 +59,51 @@ Use `.portalTransition()` to animate between source and destination.
 }
 ```
 
+## Remote Images with `AsyncImage`
+
+`AsyncImage` is supported. Apply `.portal` to a stable, sized container outside the
+`AsyncImage` phase closure so loading, failure, and success states all report the same
+anchor. Use the same container for the source, destination, and portal layer.
+
+```swift
+struct RemoteImageTransition: View {
+    let imageURL: URL
+    @State private var isShowingDetail = false
+    @Namespace private var portalNamespace
+
+    var body: some View {
+        PortalContainer {
+            remoteImage
+                .portal(id: "remote-image", as: .source, in: portalNamespace)
+                .onTapGesture { isShowingDetail = true }
+                .sheet(isPresented: $isShowingDetail) {
+                    remoteImage
+                        .portal(id: "remote-image", as: .destination, in: portalNamespace)
+                }
+                .portalTransition(
+                    id: "remote-image",
+                    in: portalNamespace,
+                    isActive: $isShowingDetail
+                ) {
+                    remoteImage
+                }
+        }
+    }
+
+    private var remoteImage: some View {
+        AsyncImage(url: imageURL) { phase in
+            if let image = phase.image {
+                image.resizable().scaledToFill()
+            } else {
+                Color.gray.opacity(0.2)
+            }
+        }
+        .frame(width: 160, height: 160)
+        .clipShape(.rect(cornerRadius: 16, style: .continuous))
+    }
+}
+```
+
 ## Examples
 
 See the included examples for complete implementations:

--- a/docs/PortalTransitions/NavigationStack.md
+++ b/docs/PortalTransitions/NavigationStack.md
@@ -1,0 +1,54 @@
+# PortalTransitions with NavigationStack
+
+Use one optional `Identifiable` selection to coordinate portal transitions for every
+item in a programmatic `NavigationStack`. The navigation path selects the destination;
+the portal selection identifies the item currently animating.
+
+```swift
+struct Product: Identifiable, Hashable {
+    let id: UUID
+    let name: String
+}
+
+struct ProductList: View {
+    let products: [Product]
+    @State private var path = NavigationPath()
+    @State private var portalItem: Product?
+    @Namespace private var portalNamespace
+
+    var body: some View {
+        PortalContainer {
+            NavigationStack(path: $path) {
+                List(products) { product in
+                    Text(product.name)
+                        .portal(item: product, as: .source, in: portalNamespace)
+                        .onTapGesture {
+                            portalItem = product
+                            path.append(product.id)
+                        }
+                }
+                .navigationDestination(for: Product.ID.self) { productID in
+                    if let product = products.first(where: { $0.id == productID }) {
+                        ProductDetail(product: product)
+                            .portal(item: product, as: .destination, in: portalNamespace)
+                            .onDisappear {
+                                if portalItem?.id == product.id {
+                                    portalItem = nil
+                                }
+                            }
+                    }
+                }
+            }
+            .portalTransition(item: $portalItem, in: portalNamespace) { product in
+                Text(product.name)
+            }
+        }
+    }
+}
+```
+
+`portalItem` is separate from `path`: it starts the forward transition before the
+destination appears, and clearing it when the detail disappears starts the reverse
+transition. Because the transition is item-based, one modifier works for every product
+in the list.
+

--- a/docs/PortalTransitions/NavigationStack.md
+++ b/docs/PortalTransitions/NavigationStack.md
@@ -1,8 +1,9 @@
 # PortalTransitions with NavigationStack
 
-Use one optional `Identifiable` selection to coordinate portal transitions for every
-item in a programmatic `NavigationStack`. The navigation path selects the destination;
-the portal selection identifies the item currently animating.
+Use `navigationDestination(item:)` with one optional `Identifiable` selection to
+coordinate portal transitions for every item in a programmatic `NavigationStack`.
+The binding drives both navigation and the portal lifecycle, including an interactive
+back gesture.
 
 ```swift
 struct Product: Identifiable, Hashable {
@@ -12,31 +13,22 @@ struct Product: Identifiable, Hashable {
 
 struct ProductList: View {
     let products: [Product]
-    @State private var path = NavigationPath()
     @State private var portalItem: Product?
     @Namespace private var portalNamespace
 
     var body: some View {
         PortalContainer {
-            NavigationStack(path: $path) {
+            NavigationStack {
                 List(products) { product in
                     Text(product.name)
                         .portal(item: product, as: .source, in: portalNamespace)
                         .onTapGesture {
                             portalItem = product
-                            path.append(product.id)
                         }
                 }
-                .navigationDestination(for: Product.ID.self) { productID in
-                    if let product = products.first(where: { $0.id == productID }) {
-                        ProductDetail(product: product)
-                            .portal(item: product, as: .destination, in: portalNamespace)
-                            .onDisappear {
-                                if portalItem?.id == product.id {
-                                    portalItem = nil
-                                }
-                            }
-                    }
+                .navigationDestination(item: $portalItem) { product in
+                    ProductDetail(product: product)
+                        .portal(item: product, as: .destination, in: portalNamespace)
                 }
             }
             .portalTransition(item: $portalItem, in: portalNamespace) { product in
@@ -47,8 +39,11 @@ struct ProductList: View {
 }
 ```
 
-`portalItem` is separate from `path`: it starts the forward transition before the
-destination appears, and clearing it when the detail disappears starts the reverse
-transition. Because the transition is item-based, one modifier works for every product
-in the list.
+Setting `portalItem` starts both the push and forward transition. When the user pops
+the detail, `navigationDestination(item:)` clears it and starts the reverse transition.
+Because the transition is item-based, one modifier works for every product in the list.
 
+When an app must use a heterogeneous `NavigationPath`, keep its route state separate
+and update the portal item only in the explicit push and pop actions. Avoid clearing the
+portal item from a destination's `onDisappear`, because that can also run when another
+destination is pushed on top.

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,7 @@ import _PortalPrivate     // View mirroring (private API)
 - [How Portal Transitions Work](PortalTransitions/HowItWorks.md)
 - [Animation Options](PortalTransitions/AnimationOptions.md)
 - [Group Animations](PortalTransitions/GroupAnimations.md)
+- [NavigationStack](PortalTransitions/NavigationStack.md)
 - [Header Snapping Behavior](PortalHeaders/SnappingBehavior.md)
 
 ## Contents
@@ -75,6 +76,7 @@ import _PortalPrivate     // View mirroring (private API)
 #### Advanced
 - [Transferring Portals](PortalTransitions/TransferringPortals.md)
 - [Group Animations](PortalTransitions/GroupAnimations.md)
+- [NavigationStack](PortalTransitions/NavigationStack.md)
 
 #### Development
 - [Debug Overlays](PortalTransitions/DebugOverlays.md)


### PR DESCRIPTION
## Summary
- Add a complete `AsyncImage` portal-transition example using a stable anchor outside image-loading phases.
- Document using a single item-based portal transition with a programmatic `NavigationStack`.

Fixes #56
Fixes #23